### PR TITLE
Add Raw gap setting

### DIFF
--- a/default.cfg.example
+++ b/default.cfg.example
@@ -27,6 +27,9 @@ spreadlend = 3
 #before placing the first (gapbottom) and last (gaptop) offer.
 #If gapbottom is set to 0, the first offer will be at the lowest possible rate.
 #However some low value is recommended (say 10%) to skip dust offers.
+# Picking a raw value (in BTC) will override the other calculated values. Comment them out to return to normal.
+#rawgapbottom = 0.5
+#rawgaptop = 1
 gapbottom = 10
 gaptop = 200
 

--- a/default.cfg.example
+++ b/default.cfg.example
@@ -26,10 +26,9 @@ spreadlend = 3
 #The depth of lendbook (in percent of lendable balance) to move through
 #before placing the first (gapbottom) and last (gaptop) offer.
 #If gapbottom is set to 0, the first offer will be at the lowest possible rate.
-#However some low value is recommended (say 10%) to skip dust offers.
-# Picking a raw value (in BTC) will override the other calculated values. Comment them out to return to normal.
-#rawgapbottom = 0.5
-#rawgaptop = 1
+#However some low value is recommended to skip dust offers.
+# Gap modes: RawBTC, Relative
+gapMode = Relative
 gapbottom = 10
 gaptop = 200
 

--- a/default.cfg.example
+++ b/default.cfg.example
@@ -23,11 +23,10 @@ maxdailyrate = 5
 #The number of offers to split the available balance across the [gaptop, gapbottom] range. (1-20)
 spreadlend = 3
 
-#The depth of lendbook (in percent of lendable balance) to move through
-#before placing the first (gapbottom) and last (gaptop) offer.
+#The depth of lendbook to move through before placing the first (gapbottom) and last (gaptop) offer.
 #If gapbottom is set to 0, the first offer will be at the lowest possible rate.
 #However some low value is recommended to skip dust offers.
-# Gap modes: RawBTC, Relative
+# Gap modes: Raw, RawBTC, Relative
 gapMode = Relative
 gapbottom = 10
 gaptop = 200

--- a/docs/configuration.rst
+++ b/docs/configuration.rst
@@ -76,6 +76,20 @@ If ``spreadlend = 1`` and ``gapbottom = 0``, it will behave as simple lending bo
     - The loans are distributed evenly between gapbottom and gaptop.
     - This allows the bot to benefit from spikes in lending rate but can result in loan fragmentation (not really a bad thing since the bot has to deal with it.)
 
+- ``rawgapbottom`` is how far into the lending book (in BTC) the bot will go, to start spreading loans.
+
+    - Default value: Commented out
+    - Allowed range: 0+
+    - Since the value is in BTC, it will be converted for each altcoin individually.
+
+- ``rawgaptop`` is how far into the lending book (in BTC) the bot will go to stop spreading loans.
+
+    - Default value: Commented out
+    - Allowed range: 0+
+    - Since the value is in BTC, it will be converted for each altcoin individually.
+
+    .. note:: Having both rawgap___ settings uncommented will enable them, recomment them to disable them.
+
 - ``gapbottom`` is how far into the lending book (in percent of YOUR total balance for the respective coin) the bot will go, to start spreading loans.
 
     - Default value: 10 percent

--- a/docs/configuration.rst
+++ b/docs/configuration.rst
@@ -76,30 +76,32 @@ If ``spreadlend = 1`` and ``gapbottom = 0``, it will behave as simple lending bo
     - The loans are distributed evenly between gapbottom and gaptop.
     - This allows the bot to benefit from spikes in lending rate but can result in loan fragmentation (not really a bad thing since the bot has to deal with it.)
 
-- ``rawgapbottom`` is how far into the lending book (in BTC) the bot will go, to start spreading loans.
+- ``gapMode`` is the "mode" you would like your gaps to be calculated in.
 
-    - Default value: Commented out
-    - Allowed range: 0+
-    - Since the value is in BTC, it will be converted for each altcoin individually.
+    - Default value: Relative
+    - Allowed values: Relative, RawBTC
+    - The values are case insensitive.
+    - The purpose of spreading your lends is to skip dust offers in the lendbook, and also to take advantage of any spikes that occur.
+    - Mode descriptions:
+        - ``Relative`` - ``Gapbottom`` and ``Gaptop`` will be relative to your balance for each coin individually.
+            - This is relative to your total lending balance, both loaned and unloaned.
+            - ``gapbottom`` and ``gaptop`` will be in percents of your balance. (A setting of 100 will equal 100%)
+            - Example: You have 1BTC. If ``gapbottom = 100`` then you will skip 100% of your balance of dust offers, thus skipping 1BTC into the lendbook. If ``gaptop = 200`` then you will continue into the lendbook until you reach 200% of your balance, thus 2BTC. Then, if ``spreadlend = 5``, you will make 5 equal volume loans over that gap.
+        - ``RawBTC`` - ``Gapbottom`` and ``Gaptop`` will be in a raw BTC value, converted to each coin.
+            - ``gapbottom`` and ``gaptop`` will be in BTC. (A setting of 3 will equal 3 BTC)
+            - Example: If ``gapbottom = 1`` and you are currently lending ETH, the bot will check the current exchange rate, say 1BTC = 10ETH. Then the bot will skip 10ETH of dust offers at the bottom of the lendbook before lending. If ``gaptop = 10``, then using the same exchange rate 10BTC will be 100ETH. The bot will then continue 100ETH into the loanbook before stopping. Then, if ``spreadlend = 5``, you will make 5 equal volume loans over that gap.
 
-- ``rawgaptop`` is how far into the lending book (in BTC) the bot will go to stop spreading loans.
 
-    - Default value: Commented out
-    - Allowed range: 0+
-    - Since the value is in BTC, it will be converted for each altcoin individually.
-
-    .. note:: Having both rawgap___ settings uncommented will enable them, recomment them to disable them.
-
-- ``gapbottom`` is how far into the lending book (in percent of YOUR total balance for the respective coin) the bot will go, to start spreading loans.
+- ``gapbottom`` is the lower setting for your ``gapMode`` values, and will be where you start to lend.
 
     - Default value: 10 percent
-    - Allowed range: 0 to <arbitrary large number> percent
+    - Allowed range: 0 to <arbitrary large number>
     - 10% gapbottom is recommended to skip past dust at the bottom of the lending book, but if you have a VERY high volume this will cause issues as you stray to far away from the most competitive bid.
 
-- ``gaptop`` is how far into the lending book (in percent of YOUR balance for the respective coin) the bot will go to stop spreading loans.
+- ``gaptop`` is the upper setting for your ``gapMode`` values, and will be where you finish spreading your lends.
 
     - Default value: 200 percent
-    - Allowed range: 0 to <arbitrary large number> percent
+    - Allowed range: 0 to <arbitrary large number>
     - This value should be adjusted based on your coin volume to avoid going astronomically far away from a realistic rate.
 
 Variable loan Length

--- a/docs/configuration.rst
+++ b/docs/configuration.rst
@@ -79,7 +79,7 @@ If ``spreadlend = 1`` and ``gapbottom = 0``, it will behave as simple lending bo
 - ``gapMode`` is the "mode" you would like your gaps to be calculated in.
 
     - Default value: Relative
-    - Allowed values: Relative, RawBTC
+    - Allowed values: Relative, RawBTC, Raw
     - The values are case insensitive.
     - The purpose of spreading your lends is to skip dust offers in the lendbook, and also to take advantage of any spikes that occur.
     - Mode descriptions:

--- a/docs/configuration.rst
+++ b/docs/configuration.rst
@@ -88,8 +88,14 @@ If ``spreadlend = 1`` and ``gapbottom = 0``, it will behave as simple lending bo
             - ``gapbottom`` and ``gaptop`` will be in percents of your balance. (A setting of 100 will equal 100%)
             - Example: You have 1BTC. If ``gapbottom = 100`` then you will skip 100% of your balance of dust offers, thus skipping 1BTC into the lendbook. If ``gaptop = 200`` then you will continue into the lendbook until you reach 200% of your balance, thus 2BTC. Then, if ``spreadlend = 5``, you will make 5 equal volume loans over that gap.
         - ``RawBTC`` - ``Gapbottom`` and ``Gaptop`` will be in a raw BTC value, converted to each coin.
+            - Recommended when using one-size-fits-all settings.
             - ``gapbottom`` and ``gaptop`` will be in BTC. (A setting of 3 will equal 3 BTC)
             - Example: If ``gapbottom = 1`` and you are currently lending ETH, the bot will check the current exchange rate, say 1BTC = 10ETH. Then the bot will skip 10ETH of dust offers at the bottom of the lendbook before lending. If ``gaptop = 10``, then using the same exchange rate 10BTC will be 100ETH. The bot will then continue 100ETH into the loanbook before stopping. Then, if ``spreadlend = 5``, you will make 5 equal volume loans over that gap.
+        - ``Raw`` - ``Gapbottom`` and ``Gaptop`` will be in a raw value of the coin being lent.
+            - Recommended when used with coin-specific settings.
+            - ``gapbottom`` and ``gaptop`` will be in value of the coin. (A setting of 3 will equal 3 BTC, 3 ETH, 3 DOGE, or whatever coin is being lent.)
+            - Example: If ``gapbottom = 1`` and you are currently lending ETH, the bot will skip 1ETH of dust offers at the bottom of the lendbook before lending. If ``gaptop = 10``, the bot will then continue 10ETH into the loanbook before stopping. Then, if ``spreadlend = 5``, you will make 5 equal volume loans over that gap.
+
 
 
 - ``gapbottom`` is the lower setting for your ``gapMode`` values, and will be where you start to lend.
@@ -271,6 +277,9 @@ Configuration should look like this::
     maxtolend = 0
     maxpercenttolend = 0
     maxtolendrate = 0
+    gapmode = raw
+    gapbottom = 10
+    gaptop = 20
 
 
 Advanced logging and Web Display
@@ -452,3 +461,4 @@ You then need to visit this `documentation page <https://docs.pushbullet.com/#li
     pushbullet = True
     pushbullet_token = l.2mDDvy4RRdzcQN9LEWSy22amS7u3LJZ1
     pushbullet_deviceid = ujpah72o0sjAoRtnM0jb
+


### PR DESCRIPTION
Allows users to set a hard value to skip in the lendbook, as opposed to only offering values relative to their balance.

Has a `gapmode` setting that allows switching between `relative`, `raw`,  or `rawbtc` gaps (and possibly even add a setting that is relative to the market's volume?)
<!--- If it fixes an open issue, please link to the issue here. -->
Closes #269 
<!--- Why is this change required? What problem does it solve? -->

## TESTING STAGE
<!--- Test your bot for at least 24 hours for most changes, certain changes may ignore this requirement. -->

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, they do not all need to be checked when you first make the PR. -->
<!--- Enter N/A in any tickboxes that do not apply to your change. Example: "- [N/A] Blah blah..."
<!--- For us to merge your PR, after approval, ALL OF THESE CHECKBOXES NEED TO BE TICKED -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] **I have read CONTRIBUTING.md**
- [x] **I fully understand [Github Flow.](https://guides.github.com/introduction/flow/)**
- [x] **My code adheres to the [code style of this project.](https://poloniexlendingbot.readthedocs.io/en/latest/contributing.html)**
- [x] **I have updated the documentation in /docs if I have changed the config, arguments, logic in how the bot works, or anything that understandably needs a documentation change.**
- [x] **I have updated the config file accordingly if my change requires a new configuration setting or changes an existing one.**
- [x] **I have tested the bot with no issues for 24 continuous hours. If issues were experienced, they have been patched and tested again.**