### PR TITLE
don't output large dump of html from Cloudflare on 502 Gateway Error

### DIFF
--- a/modules/Poloniex.py
+++ b/modules/Poloniex.py
@@ -125,14 +125,15 @@ class Poloniex:
                 json_ret = _read_response(ret)
                 return post_process(json_ret)
         except urllib2.HTTPError as ex:
+            raw_polo_response = ex.read()
             try:
-                data = json.loads(ex.read())
+                data = json.loads(raw_polo_response)
                 polo_error_msg = data['error']
             except:
-                polo_error_msg = None
+                polo_error_msg = raw_polo_response
             ex.message = ex.message if ex.message else str(ex)
             ex.message = "{0} Requesting {1}.  Poloniex reports: '{2}'".format(ex.message, command, polo_error_msg)
-            raise
+            raise ex
         except Exception as ex:
             ex.message = ex.message if ex.message else str(ex)
             ex.message = "{0} Requesting {1}".format(ex.message, command)

--- a/modules/Poloniex.py
+++ b/modules/Poloniex.py
@@ -130,7 +130,10 @@ class Poloniex:
                 data = json.loads(raw_polo_response)
                 polo_error_msg = data['error']
             except:
-                polo_error_msg = raw_polo_response
+                if ex.code == 502:  # 502 Bad Gateway so response is likely HTML from Cloudflare
+                    polo_error_msg = ''
+                else:
+                    polo_error_msg = raw_polo_response
             ex.message = ex.message if ex.message else str(ex)
             ex.message = "{0} Requesting {1}.  Poloniex reports: '{2}'".format(ex.message, command, polo_error_msg)
             raise ex


### PR DESCRIPTION
dealing with issue commented on #390 ... The API seems to respond with a page of HTML when Cloudflare is not able to communicate with the backend.  It's unlikely to get any useful information from the content on a 502 error so we skip outputting that.

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, they do not all need to be checked when you first make the PR. -->
<!--- Enter N/A in any tickboxes that do not apply to your change. Example: "- [N/A] Blah blah..."
<!--- For us to merge your PR, after approval, ALL OF THESE CHECKBOXES NEED TO BE TICKED -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] **I have read CONTRIBUTING.md**
- [x] **I fully understand [Github Flow.](https://guides.github.com/introduction/flow/)**
- [x] **My code adheres to the [code style of this project.](https://poloniexlendingbot.readthedocs.io/en/latest/contributing.html)**
- [n/a] **I have updated the documentation in /docs if I have changed the config, arguments, logic in how the bot works, or anything that understandably needs a documentation change.**
- [n/a] **I have updated the config file accordingly if my change requires a new configuration setting or changes an existing one.**
- [n/a] **I have tested the bot with no issues for 24 continuous hours. If issues were experienced, they have been patched and tested again.**
