### PR TITLE
Fixes #384

### DIFF
--- a/modules/Lending.py
+++ b/modules/Lending.py
@@ -368,7 +368,7 @@ def get_gap_mode_rates(cur, cur_active_bal, cur_total_balance, ticker):
             gap_mode_default = "relative"
             gap_bottom_default = 10
             gap_top_default = 200
-        return construct_orders(cur, cur_active_bal, cur_total_balance, ticker)  # Start over with new defaults
+        return get_gap_mode_rates(cur, cur_active_bal, cur_total_balance, ticker)  # Start over with new defaults
     return [Decimal(top_rate), Decimal(bottom_rate)]
 
 


### PR DESCRIPTION
## Description
When a user does not have a gapMode set in their configuration the bot was trying to set some defaults for the gap mode and then get proper gap mode rates. It was calling the wrong function in this case and returning a dictionary instead of a list of decimal values. This caused the exception.


## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [X] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, they do not all need to be checked when you first make the PR. -->
<!--- Enter N/A in any tickboxes that do not apply to your change. Example: "- [N/A] Blah blah..."
<!--- For us to merge your PR, after approval, ALL OF THESE CHECKBOXES NEED TO BE TICKED -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [X] **I have read CONTRIBUTING.md**
- [X] **I fully understand [Github Flow.](https://guides.github.com/introduction/flow/)**
- [X] **My code adheres to the [code style of this project.](https://poloniexlendingbot.readthedocs.io/en/latest/contributing.html)**
- [N/A] **I have updated the documentation in /docs if I have changed the config, arguments, logic in how the bot works, or anything that understandably needs a documentation change.**
- [N/A] **I have updated the config file accordingly if my change requires a new configuration setting or changes an existing one.**
- [ ] **I have tested the bot with no issues for 24 continuous hours. If issues were experienced, they have been patched and tested again.**
