### PR TITLE
Put messages in a .format to stop TypeErrors

### DIFF
--- a/modules/Logger.py
+++ b/modules/Logger.py
@@ -91,11 +91,12 @@ class Logger(object):
         return datetime.datetime.fromtimestamp(ts).strftime('%Y-%m-%d %H:%M:%S')
 
     def log(self, msg):
-        self.output.printline(self.timestamp() + ' ' + msg)
+        log_message = "{0} {1}".format(self.timestamp(), msg)
+        self.output.printline(log_message)
         self.refreshStatus()
 
     def log_error(self, msg):
-        log_message = self.timestamp() + ' Error: ' + msg
+        log_message = "{0} Error {1}".format(self.timestamp(), msg)
         self.output.printline(log_message)
         if type(self.output) is JsonOutput:
             print log_message


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->
<!--- If it fixes an open issue, please link to the issue here. -->
<!--- Why is this change required? What problem does it solve? -->
Closes #374 

Wrap messages in a .format to get around TypeErrors.

Could have changed more, but the logging module needs an overhaul in the future anyway.

## TESTING STAGE
<!--- Test your bot for at least 24 hours for most changes, certain changes may ignore this requirement. -->
Testing

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [X] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, they do not all need to be checked when you first make the PR. -->
<!--- Enter N/A in any tickboxes that do not apply to your change. Example: "- [N/A] Blah blah..."
<!--- For us to merge your PR, after approval, ALL OF THESE CHECKBOXES NEED TO BE TICKED -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [X] **I have read CONTRIBUTING.md**
- [X] **I fully understand [Github Flow.](https://guides.github.com/introduction/flow/)**
- [X] **My code adheres to the [code style of this project.](https://poloniexlendingbot.readthedocs.io/en/latest/contributing.html)**
- [N/A] **I have updated the documentation in /docs if I have changed the config, arguments, logic in how the bot works, or anything that understandably needs a documentation change.**
- [N/A] **I have updated the config file accordingly if my change requires a new configuration setting or changes an existing one.**
- [ ] **I have tested the bot with no issues for 24 continuous hours. If issues were experienced, they have been patched and tested again.**
