### PR TITLE
Added timeout to API request for prevent hung

### DIFF
--- a/modules/Bitfinex.py
+++ b/modules/Bitfinex.py
@@ -21,6 +21,7 @@ class Bitfinex(ExchangeApi):
         self.ticker = {}
         self.tickerTime = 0
         self.usedCurrencies = []
+        self.timeout = int(self.cfg.get("BOT", "timeout", 30, 1, 180))
 
     @property
     def _nonce(self):
@@ -46,9 +47,9 @@ class Bitfinex(ExchangeApi):
         try:
             r = {}
             if (request == 'get'):
-                r = requests.get(self.url + command)
+                r = requests.get(self.url + command, timeout=self.timeout)
             else:
-                r = requests.post(self.url + command, headers=payload, verify=verify)
+                r = requests.post(self.url + command, headers=payload, verify=verify, timeout=self.timeout)
 
             if r.status_code != 200:
                 if (r.status_code in [502, 504, 522]):


### PR DESCRIPTION
In case of network or exchange problem, it's a possible that bot is hung during API request.
Adding timeout value fixed the hung problem.

## Description
Fixed issue #449 with bot hung during work with bitfinex.


## TESTING STAGE
Tested for a few days. No hungs was observed.
<!--- Test your bot for at least 24 hours for most changes, certain changes may ignore this requirement. -->

## Types of changes
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, they do not all need to be checked when you first make the PR. -->
<!--- Enter N/A in any tickboxes that do not apply to your change. Example: "- [N/A] Blah blah..."
<!--- For us to merge your PR, after approval, ALL OF THESE CHECKBOXES NEED TO BE TICKED -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] **I have read CONTRIBUTING.md**
- [x] **I fully understand [Github Flow.](https://guides.github.com/introduction/flow/)**
- [x] **My code adheres to the [code style of this project.](https://poloniexlendingbot.readthedocs.io/en/latest/contributing.html)**
- [ ] **I have updated the documentation in /docs if I have changed the config, arguments, logic in how the bot works, or anything that understandably needs a documentation change.**
- [ ] **I have updated the config file accordingly if my change requires a new configuration setting or changes an existing one.**
- [x] **I have tested the bot with no issues for 24 continuous hours. If issues were experienced, they have been patched and tested again.**
