### PR TITLE
Allow to change default bot name in html page

### DIFF
--- a/default.cfg.example
+++ b/default.cfg.example
@@ -15,6 +15,9 @@ all_currencies = STR,BTC,BTS,CLAM,DOGE,DASH,LTC,MAID,XMR,XRP,ETH,FCT
 all_currencies = USD,BTC,ETH,ETC,ZEC,XMR,LTC,DSH,IOT,EOS,BCH
 
 [BOT]
+#Custom name of the bot, that will be displayed in html page
+label = Lending Bot
+
 #Sleeps between active iterations, time in seconds (1-3600)
 sleeptimeactive = 60
 

--- a/docs/configuration.rst
+++ b/docs/configuration.rst
@@ -365,6 +365,12 @@ Advanced logging and Web Display
     - Acceptable values: BTC, USDT, Any coin with a direct Poloniex BTC trading pair (ex. DOGE, MAID, ETH), Currencies that have a BTC exchange rate on blockchain.info (i.e. EUR, USD)
     - Will be a close estimate, due to unexpected market fluctuations, trade fees, and other unforseeable factors.
 
+- ``label`` is a custom name of the bot, that will be displayed in html page.
+
+    - Default value: Lending Bot
+    - Allowed values: Any literal string
+
+
 Plugins
 -------
 

--- a/lendingbot.py
+++ b/lendingbot.py
@@ -63,7 +63,7 @@ Lending.init(Config, api, log, Data, MaxToLend, dry_run, analysis, notify_conf)
 # load plugins
 PluginsManager.init(Config, api, log, notify_conf)
 
-print 'Welcome to Lending Bot on ' + exchange
+print 'Welcome to ' + Config.get("BOT", "label", "Lending Bot") + ' on ' + exchange
 
 # Configure web server
 web_server_enabled = Config.getboolean('BOT', 'startWebServer')

--- a/modules/Logger.py
+++ b/modules/Logger.py
@@ -7,6 +7,7 @@ import sys
 import time
 
 import ConsoleUtils
+import modules.Configuration as Config
 from RingBuffer import RingBuffer
 from Notify import send_notification
 
@@ -47,6 +48,7 @@ class JsonOutput(object):
         self.clearStatusValues()
         self.jsonOutputLog = RingBuffer(logLimit)
         self.jsonOutput['exchange'] = exchange
+        self.jsonOutput['label'] = Config.get("BOT", "label", "Lending Bot")
 
     def status(self, status, time, days_remaining_msg):
         self.jsonOutput["last_update"] = time + days_remaining_msg

--- a/www/lendingbot.js
+++ b/www/lendingbot.js
@@ -27,8 +27,8 @@ var btcDisplayUnitsModes = [BTC, mBTC, Bits, Satoshi];
 function updateJson(data) {
     $('#status').text(data.last_status);
     $('#updated').text(data.last_update);
-    $('#title').text(data.exchange + ' Lending Bot')
-    document.title = data.exchange + ' Lending Bot'
+    $('#title').text(data.exchange + ' ' + data.label)
+    document.title = data.exchange + ' ' + data.label
 
     var rowCount = data.log.length;
     var table = $('#logtable');


### PR DESCRIPTION
Bot usually start with name 'Lending bot'.
In case few instances of bot work at the same time it is useful to customize the name that allows identifying instance quickly.

## Description
Added configuration option '[BOT] label' that define the unique name of the bot instance. This name is used in html page and console logs.

## TESTING STAGE
This changes don't change bots behavior during work and could be verified during start-up
<!--- Test your bot for at least 24 hours for most changes, certain changes may ignore this requirement. -->

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, they do not all need to be checked when you first make the PR. -->
<!--- Enter N/A in any tickboxes that do not apply to your change. Example: "- [N/A] Blah blah..."
<!--- For us to merge your PR, after approval, ALL OF THESE CHECKBOXES NEED TO BE TICKED -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] **I have read CONTRIBUTING.md**
- [x] **I fully understand [Github Flow.](https://guides.github.com/introduction/flow/)**
- [x] **My code adheres to the [code style of this project.](https://poloniexlendingbot.readthedocs.io/en/latest/contributing.html)**
- [ ] **I have updated the documentation in /docs if I have changed the config, arguments, logic in how the bot works, or anything that understandably needs a documentation change.**
- [x] **I have updated the config file accordingly if my change requires a new configuration setting or changes an existing one.**
- [ ] **I have tested the bot with no issues for 24 continuous hours. If issues were experienced, they have been patched and tested again.**
