### PR TITLE
Option to compact log output

### DIFF
--- a/default.cfg.example
+++ b/default.cfg.example
@@ -105,6 +105,10 @@ hideCoins = True
 #Limits the amount of log lines to save.
 #jsonlogsize = 200
 
+#If True some frequent log messages (e.g. "Not lending ... due to rate below ..." will not append to log list.
+#Last equal log message will be shown in currency web page section. Default is false
+#jsonlogcompact = true
+
 #Enables a webserver for the www folder, in order to easily use the lendingbot.html with the .json log.
 #startWebServer = true
 

--- a/docs/configuration.rst
+++ b/docs/configuration.rst
@@ -292,6 +292,12 @@ Advanced logging and Web Display
     - Format: ``200``
     - Reasons to lower this include: you are conscious of bandwidth when hosting your webserver, you prefer (slightly) faster loading times and less RAM usage of bot.
 
+- ``jsonlogcompact`` enables to log frequent repeated log messages (like "Not lending due to rate below ...") to
+currency web page section instead of appending to log list. If enabled only last message is displayed.
+
+    - Default value: Commented out, compacting of log is disabled (false)
+    - Allowed values: true, false
+
 - ``startWebServer`` if true, this enables a webserver on the www/ folder.
 
     - Default value: Commented out, uncomment to enable.

--- a/modules/Lending.py
+++ b/modules/Lending.py
@@ -412,8 +412,7 @@ def lend_cur(active_cur, total_lent, lending_balances, ticker):
         below_min = Decimal(orders['rates'][i]) < Decimal(cur_min_daily_rate)
 
         if hide_coins and below_min:
-            log.log("Not lending {:s} due to rate below {:.4f}% (actual: {:.4f}%)"
-                    .format(active_cur, (cur_min_daily_rate * 100), (orders['rates'][i] * 100)))
+            log.notLending(active_cur, cur_min_daily_rate, orders['rates'][i])
             return 0
         elif below_min:
             rate = str(cur_min_daily_rate)

--- a/www/lendingbot.js
+++ b/www/lendingbot.js
@@ -120,6 +120,7 @@ function updateRawValues(rawData){
         var totalCoins = parseFloat(rawData[currency]['totalCoins']);
         var maxToLend = parseFloat(rawData[currency]['maxToLend']);
         var highestBidBTC = parseFloat(rawData[currency]['highestBid']);
+        var compactLog = 'log' in rawData[currency] ? rawData[currency]['log'] : ''
 
         if (currency == 'BTC') {
             // no bids for BTC provided by poloniex
@@ -208,12 +209,20 @@ function updateRawValues(rawData){
             }
             $(row).find('[data-toggle="tooltip"]').tooltip();
 
+            if (compactLog.length > 0) {
+                table.insertRow()
+                row = table.insertRow()
+                var cell = row.appendChild(document.createElement("td"))
+                cell.setAttribute("colspan", rowValues.length)
+                cell.innerHTML = "<div class='inlinediv' >" + compactLog + "</div>"
+            }
+
             var earningsColspan = rowValues.length - 1;
             // print coin earnings
             var row = table.insertRow();
             if (lentSum > 0) {
                 var cell1 = row.appendChild(document.createElement("td"));
-                cell1.innerHTML = "<span class='hidden-xs'>"+ displayCurrency +"<br/></span>Est. "+ compoundRateText +"<br/>Earnings";
+                cell1.innerHTML = "Est. "+ compoundRateText +"<br/>Earnings"
                 var cell2 = row.appendChild(document.createElement("td"));
                 cell2.setAttribute("colspan", earningsColspan);
                 if (earningsSummaryCoin != '') {


### PR DESCRIPTION
New option ``jsonlogcompact`` enables to log frequent repeated log messages (like "Not lending due to rate below ...") to currency web page section instead of appending to log list. If enabled only last message is displayed.

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, they do not all need to be checked when you first make the PR. -->
<!--- Enter N/A in any tickboxes that do not apply to your change. Example: "- [N/A] Blah blah..."
<!--- For us to merge your PR, after approval, ALL OF THESE CHECKBOXES NEED TO BE TICKED -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] **I have read CONTRIBUTING.md**
- [x] **I fully understand [Github Flow.](https://guides.github.com/introduction/flow/)**
- [x] **My code adheres to the [code style of this project.](https://poloniexlendingbot.readthedocs.io/en/latest/contributing.html)**
- [x] **I have updated the documentation in /docs if I have changed the config, arguments, logic in how the bot works, or anything that understandably needs a documentation change.**
- [x] **I have updated the config file accordingly if my change requires a new configuration setting or changes an existing one.**
- [x] **I have tested the bot with no issues for 24 continuous hours. If issues were experienced, they have been patched and tested again.**
