### PR TITLE
Fix 'Incorrect coin entered for transferCurrencies' #483

### DIFF
--- a/modules/Bitfinex.py
+++ b/modules/Bitfinex.py
@@ -292,7 +292,9 @@ class Bitfinex(ExchangeApi):
         https://bitfinex.readme.io/v1/reference#rest-auth-wallet-balances
         """
         balances = self.return_available_account_balances('exchange')
-        return balances['exchange']
+        return_dict = {cur: u'0.00000000' for cur in self.cfg.get_all_currencies()}
+        return_dict.update(balances['exchange'])
+        return return_dict
 
     def transfer_balance(self, currency, amount, from_account, to_account):
         """


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
Closes #483 
## Description
<!--- Describe your changes in detail -->
<!--- If it fixes an open issue, please link to the issue here. -->
<!--- Why is this change required? What problem does it solve? -->

Returns all currencies the bot is configured for on Bitfinex when requested, even if the balance is 0. 

## TESTING STAGE
<!--- Test your bot for at least 24 hours for most changes, certain changes may ignore this requirement. -->

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, they do not all need to be checked when you first make the PR. -->
<!--- Enter N/A in any tickboxes that do not apply to your change. Example: "- [N/A] Blah blah..."
<!--- For us to merge your PR, after approval, ALL OF THESE CHECKBOXES NEED TO BE TICKED -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] **I have read CONTRIBUTING.md**
- [x] **I fully understand [Github Flow.](https://guides.github.com/introduction/flow/)**
- [x] **My code adheres to the [code style of this project.](https://poloniexlendingbot.readthedocs.io/en/latest/contributing.html)**
- [N/A] **I have updated the documentation in /docs if I have changed the config, arguments, logic in how the bot works, or anything that understandably needs a documentation change.**
- [N/A] **I have updated the config file accordingly if my change requires a new configuration setting or changes an existing one.**
- [ ] **I have tested the bot with no issues for 24 continuous hours. If issues were experienced, they have been patched and tested again.**
