### PR TITLE
Change min/max daily lend rate depending on exchange (and simplify xdays)

### DIFF
--- a/modules/Lending.py
+++ b/modules/Lending.py
@@ -40,7 +40,6 @@ gap_mode_default = ""
 scheduler = None
 exchange = None
 
-
 # limit of orders to request
 loanOrdersRequestLimit = {}
 defaultLoanOrdersRequestLimit = 100

--- a/modules/Lending.py
+++ b/modules/Lending.py
@@ -58,14 +58,20 @@ def init(cfg, api1, log1, data, maxtolend, dry_run1, analysis, notify_conf1):
     global sleep_time, sleep_time_active, sleep_time_inactive, min_daily_rate, max_daily_rate, spread_lend, \
         gap_bottom_default, gap_top_default, xday_threshold, xday_spread, xdays, min_loan_size, end_date, coin_cfg, \
         min_loan_sizes, dry_run, transferable_currencies, keep_stuck_orders, hide_coins, scheduler, gap_mode_default, \
-        exchange, analysis_method, currencies_to_analyse 
+        exchange, analysis_method, currencies_to_analyse
 
     exchange = Config.get_exchange()
 
     sleep_time_active = float(Config.get("BOT", "sleeptimeactive", None, 1, 3600))
     sleep_time_inactive = float(Config.get("BOT", "sleeptimeinactive", None, 1, 3600))
-    min_daily_rate = Decimal(Config.get("BOT", "mindailyrate", None, 0.003, 5)) / 100
-    max_daily_rate = Decimal(Config.get("BOT", "maxdailyrate", None, 0.003, 5)) / 100
+    if exchange == 'BITFINEX':
+        min_daily_rate = Decimal(Config.get("BOT", "mindailyrate", None, 0.003, 7)) / 100
+    else:
+        min_daily_rate = Decimal(Config.get("BOT", "mindailyrate", None, 0.003, 5)) / 100
+    if exchange == 'BITFINEX':
+        max_daily_rate = Decimal(Config.get("BOT", "maxdailyrate", None, 0.003, 7)) / 100
+    else:
+        max_daily_rate = Decimal(Config.get("BOT", "maxdailyrate", None, 0.003, 5)) / 100
     spread_lend = int(Config.get("BOT", "spreadlend", None, 1, 20))
     gap_mode_default = Config.get_gap_mode("BOT", "gapMode")
     gap_bottom_default = Decimal(Config.get("BOT", "gapbottom", None, 0))

--- a/modules/Lending.py
+++ b/modules/Lending.py
@@ -40,6 +40,7 @@ gap_mode_default = ""
 scheduler = None
 exchange = None
 
+
 # limit of orders to request
 loanOrdersRequestLimit = {}
 defaultLoanOrdersRequestLimit = 100
@@ -64,24 +65,17 @@ def init(cfg, api1, log1, data, maxtolend, dry_run1, analysis, notify_conf1):
 
     sleep_time_active = float(Config.get("BOT", "sleeptimeactive", None, 1, 3600))
     sleep_time_inactive = float(Config.get("BOT", "sleeptimeinactive", None, 1, 3600))
-    if exchange == 'BITFINEX':
-        min_daily_rate = Decimal(Config.get("BOT", "mindailyrate", None, 0.003, 7)) / 100
-    else:
-        min_daily_rate = Decimal(Config.get("BOT", "mindailyrate", None, 0.003, 5)) / 100
-    if exchange == 'BITFINEX':
-        max_daily_rate = Decimal(Config.get("BOT", "maxdailyrate", None, 0.003, 7)) / 100
-    else:
-        max_daily_rate = Decimal(Config.get("BOT", "maxdailyrate", None, 0.003, 5)) / 100
+    exchangeMax = 7 if exchange == 'BITFINEX' else 5
+    min_daily_rate = Decimal(Config.get("BOT", "mindailyrate", None, 0.003, exchangeMax)) / 100
+    max_daily_rate = Decimal(Config.get("BOT", "maxdailyrate", None, 0.003, exchangeMax)) / 100
     spread_lend = int(Config.get("BOT", "spreadlend", None, 1, 20))
     gap_mode_default = Config.get_gap_mode("BOT", "gapMode")
     gap_bottom_default = Decimal(Config.get("BOT", "gapbottom", None, 0))
     gap_top_default = Decimal(Config.get("BOT", "gaptop", None, gap_bottom_default))
     xday_threshold = float(Config.get("BOT", "xdaythreshold", None, 0.003, 5)) / 100
     xday_spread = float(Config.get('BOT', 'xdayspread', 0, 0, 10))
-    if exchange == 'BITFINEX':
-        xdays = str(Config.get("BOT", "xdays", None, 2, 30))
-    else:
-        xdays = str(Config.get("BOT", "xdays", None, 2, 60))
+    maxPeriod = 30 if exchange == 'BITFINEX' else 60
+    xdays = str(Config.get("BOT", "xdays", None, 2, maxPeriod))
     min_loan_size = Decimal(Config.get("BOT", 'minloansize', None, 0.01))
     end_date = Config.get('BOT', 'endDate')
     coin_cfg = Config.get_coin_cfg()

--- a/modules/Lending.py
+++ b/modules/Lending.py
@@ -58,7 +58,7 @@ def init(cfg, api1, log1, data, maxtolend, dry_run1, analysis, notify_conf1):
     global sleep_time, sleep_time_active, sleep_time_inactive, min_daily_rate, max_daily_rate, spread_lend, \
         gap_bottom_default, gap_top_default, xday_threshold, xday_spread, xdays, min_loan_size, end_date, coin_cfg, \
         min_loan_sizes, dry_run, transferable_currencies, keep_stuck_orders, hide_coins, scheduler, gap_mode_default, \
-        exchange, analysis_method, currencies_to_analyse
+        exchange, analysis_method, currencies_to_analyse 
 
     exchange = Config.get_exchange()
 


### PR DESCRIPTION
## Description
Allowing bot to change the max daily lending rate percent, which is 7% on Bitfinex and 5% on Poloniex, depending on current exchange being used

## TESTING STAGE
tested for 24 hours + and executed at least one loan offer on Bitfinex

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
- [x] **I have read CONTRIBUTING.md**
- [x] **I fully understand [Github Flow.](https://guides.github.com/introduction/flow/)**
- [x] **My code adheres to the [code style of this project.](https://poloniexlendingbot.readthedocs.io/en/latest/contributing.html)**
- [x] **I have updated the documentation in /docs if I have changed the config, arguments, logic in how the bot works, or anything that understandably needs a documentation change.**
- [x] **I have updated the config file accordingly if my change requires a new configuration setting or changes an existing one.**
- [x] **I have tested the bot with no issues for 24 continuous hours. If issues were experienced, they have been patched and tested again.**
