### PR TITLE
Addition of a Slack Username parameter as a configuration option.

### DIFF
--- a/default.cfg.example
+++ b/default.cfg.example
@@ -171,6 +171,7 @@ email_to_addresses = me@gmail.com,you@gmail.com
 slack = False
 slack_token = 1234567890abcdef
 slack_channels = #cryptocurrency,@someUser
+slack_username = Poloniex Bot
 
 telegram = False
 telegram_bot_id = 1234567890abcdef

--- a/modules/Configuration.py
+++ b/modules/Configuration.py
@@ -218,6 +218,8 @@ def get_notification_config():
         for conf in ['slack_token', 'slack_channels', 'slack_username']:
             notify_conf[conf] = get('notifications', conf)
         notify_conf['slack_channels'] = notify_conf['slack_channels'].split(',')
+        if not notify_conf['slack_username']:
+            notify_conf['slack_username'] = 'Slack API Tester'
 
     if notify_conf['telegram']:
         for conf in ['telegram_bot_id', 'telegram_chat_ids']:

--- a/modules/Configuration.py
+++ b/modules/Configuration.py
@@ -215,7 +215,7 @@ def get_notification_config():
         notify_conf['email_to_addresses'] = notify_conf['email_to_addresses'].split(',')
 
     if notify_conf['slack']:
-        for conf in ['slack_token', 'slack_channels']:
+        for conf in ['slack_token', 'slack_channels', 'slack_username']:
             notify_conf[conf] = get('notifications', conf)
         notify_conf['slack_channels'] = notify_conf['slack_channels'].split(',')
 
@@ -242,5 +242,3 @@ def get_plugins_config():
     if config.has_option("BOT", "plugins"):
         active_plugins = map(str.strip, config.get("BOT", "plugins").split(','))
     return active_plugins
-
-

--- a/modules/Notify.py
+++ b/modules/Notify.py
@@ -38,9 +38,9 @@ def check_urlib_response(response, platform):
         raise NotificationException(msg)
 
 
-def post_to_slack(msg, channels, token):
+def post_to_slack(msg, channels, token, username):
     for channel in channels:
-        post_data = {'text': msg, 'channel': channel, 'token': token}
+        post_data = {'text': msg, 'channel': channel, 'token': token, 'username': username}
         enc_post_data = urllib.urlencode(encoded_dict(post_data))
         url = 'https://{}/api/{}'.format('slack.com', 'chat.postMessage')
         response = urllib2.urlopen(url, enc_post_data)
@@ -121,7 +121,7 @@ def send_notification(_msg, notify_conf):
         send_email(msg, nc['email_login_address'], nc['email_login_password'], nc['email_smtp_server'],
                    nc['email_smtp_port'], nc['email_to_addresses'], nc['email_smtp_starttls'])
     if nc['slack']:
-        post_to_slack(msg, nc['slack_channels'], nc['slack_token'])
+        post_to_slack(msg, nc['slack_channels'], nc['slack_token'], nc['slack_username'])
     if nc['telegram']:
         post_to_telegram(msg, nc['telegram_chat_ids'], nc['telegram_bot_id'])
     if nc['pushbullet']:


### PR DESCRIPTION
## Description
<!--- Describe your changes in detail -->
<!--- If it fixes an open issue, please link to the issue here. -->
<!--- Why is this change required? What problem does it solve? -->
Adds the ability to set a Slack Username for the Bot notifications via a configuration value. This is a PR for #575. 

## TESTING STAGE
<!--- Test your bot for at least 24 hours for most changes, certain changes may ignore this requirement. -->
I've had these changes running for over 24 hours in my testing without issue.

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, they do not all need to be checked when you first make the PR. -->
<!--- Enter N/A in any tickboxes that do not apply to your change. Example: "- [N/A] Blah blah..."
<!--- For us to merge your PR, after approval, ALL OF THESE CHECKBOXES NEED TO BE TICKED -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] **I have read CONTRIBUTING.md**
- [x] **I fully understand [Github Flow.](https://guides.github.com/introduction/flow/)**
- [x] **My code adheres to the [code style of this project.](https://poloniexlendingbot.readthedocs.io/en/latest/contributing.html)**
- [x] **I have updated the documentation in /docs if I have changed the config, arguments, logic in how the bot works, or anything that understandably needs a documentation change.**
- [x] **I have updated the config file accordingly if my change requires a new configuration setting or changes an existing one.**
- [x] **I have tested the bot with no issues for 24 continuous hours. If issues were experienced, they have been patched and tested again.**
