### PR TITLE
Use docker image with pandas and numpy already installed

### DIFF
--- a/docker-compose.yaml
+++ b/docker-compose.yaml
@@ -35,7 +35,7 @@ services:
   poloniex:
     depends_on:
       - nginx
-    image: python:2.7-slim
+    image: amancevice/pandas:0.21.0-python2
     restart: always
     working_dir: /usr/src/app/
     environment:
@@ -56,7 +56,7 @@ services:
   bitfinex:
     depends_on:
       - nginx
-    image: python:2.7-slim
+    image: amancevice/pandas:0.21.0-python2
     restart: always
     working_dir: /usr/src/app/
     environment:


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
Closes #574 

This new image has numpy and pandas already installed, this greatly improves start up time and allows it to be used on hosts that cannot compile numpy / pandas (Some Raspberry PI and some NAS devices)

## Description
<!--- Describe your changes in detail -->
<!--- If it fixes an open issue, please link to the issue here. -->
<!--- Why is this change required? What problem does it solve? -->

## TESTING STAGE
<!--- Test your bot for at least 24 hours for most changes, certain changes may ignore this requirement. -->

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [X] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, they do not all need to be checked when you first make the PR. -->
<!--- Enter N/A in any tickboxes that do not apply to your change. Example: "- [N/A] Blah blah..."
<!--- For us to merge your PR, after approval, ALL OF THESE CHECKBOXES NEED TO BE TICKED -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [X] **I have read CONTRIBUTING.md**
- [X] **I fully understand [Github Flow.](https://guides.github.com/introduction/flow/)**
- [X] **My code adheres to the [code style of this project.](https://poloniexlendingbot.readthedocs.io/en/latest/contributing.html)**
- [N/A] **I have updated the documentation in /docs if I have changed the config, arguments, logic in how the bot works, or anything that understandably needs a documentation change.**
- [N/A] **I have updated the config file accordingly if my change requires a new configuration setting or changes an existing one.**
- [X] **I have tested the bot with no issues for 24 continuous hours. If issues were experienced, they have been patched and tested again.**
