### PR TITLE
remove coinconfig one line

### DIFF
--- a/default.cfg.example
+++ b/default.cfg.example
@@ -98,15 +98,6 @@ hideCoins = True
 # The Flash Return Rate Delta (frrdelta) is a dynamic funding rate option that allows you to specify an offset from the Flash Return Rate. This only works on bitfinex and ffrasmin = TRUE
 frrdelta = 0.0000
 
-#Syntax: ["COIN:mindailyrate:maxactiveamount:maxtolend:maxpercenttolend:maxtolendrate",...]
-#If maxactive amount is 0: stop lending this coin. in the future you'll be able to limit amount to be lent.
-#If maxtolend is 0: check for maxpercenttolend.
-#If maxpercenttolend is 0: 100% is going to be lent.
-#If maxtolendrate is set to more than 0: the maxtolend or maxpercenttolend will be used when then rate is less or equal to the maxtolendrate. if set to 0 the bot will use the maxtolend or maxpercenttolend all the time.
-# Please configure via the coinconfig line below OR individual coins in the [BTC], [CLAM], etc section. NOT both.
-# coinconfig takes precedence
-#coinconfig = ["BTC:0.18:1:0:0:0","CLAM:0.6:1:0:0:0"]
-
 #This option creates a json log file instead of console output which includes the most recent status.
 #Uncomment both jsonfile and jsonlogsize to enable.
 #Keep this in the default location if you want to use the webserver.
@@ -142,7 +133,7 @@ frrdelta = 0.0000
 #DumpInterval = 21600
 #HistoryFile = www/history.json
 
-# Currencies can be configured here, or in the coinconfig. Coinconfig takes precedence.
+# Currencies can be configured here.
 #[BTC]
 #minloansize = 0.01
 #mindailyrate = 0.18

--- a/docs/configuration.rst
+++ b/docs/configuration.rst
@@ -280,15 +280,7 @@ This can be configured in one of two ways.
 
 **Coincfg dictionary**
 
-- ``coincfg`` is in the form of a dictionary and allows for advanced, per-coin options.
-
-    - Default value: Commented out, uncomment to enable.
-    - Format: ``["COINTICKER:MINLENDRATE:ENABLED?:MAXTOLEND:MAXPERCENTTOLEND:MAXTOLENDRATE","CLAM:0.6:1:0:.75:.1",...]``
-    - COINTICKER refers to the ticker of the coin, ex. BTC, CLAM, MAID, DOGE.
-    - MINLENDRATE is that coins minimum lending rate, overrides the global setting. Follows the limits of ``minlendrate``
-    - ENABLED? refers to a value of ``0`` if the coin is disabled and will no longer lend. Any positive integer will enable lending for the coin.
-    - MAXTOLEND, MAXPERCENTTOLEND, and MAXTOLENDRATE refer to their respective settings above, but are unique to the specified coin specifically.
-    - There can be as many different coins as you want in coincfg, but each coin may only appear once.
+- ``coinconfig`` is now DEPRECATED, please switch to using separate coin sections as described below.
 
 **Separate coin sections**
 

--- a/docs/configuration.rst
+++ b/docs/configuration.rst
@@ -280,7 +280,7 @@ This can be configured in one of two ways.
 
 **Coincfg dictionary**
 
-- ``coinconfig`` is now DEPRECATED, please switch to using separate coin sections as described below.
+- ``coinconfig`` is now REMOVED, please switch to using separate coin sections as described below.
 
 **Separate coin sections**
 

--- a/modules/Configuration.py
+++ b/modules/Configuration.py
@@ -28,7 +28,7 @@ def init(file_location, data=None):
             print("Failed to automatically copy config. Please do so manually. Error: {0}".format(ex.message))
             exit(1)
     if config.has_option("BOT", "coinconfig"):
-        print('\'coinconfig\' has been deprecated, please use section coin config instead.\n'
+        print('\'coinconfig\' has been removed, please use section coin config instead.\n'
               'See: http://poloniexlendingbot.readthedocs.io/en/latest/configuration.html#config-per-coin')
         exit(1)
     return config

--- a/modules/Configuration.py
+++ b/modules/Configuration.py
@@ -27,6 +27,10 @@ def init(file_location, data=None):
             ex.message = ex.message if ex.message else str(ex)
             print("Failed to automatically copy config. Please do so manually. Error: {0}".format(ex.message))
             exit(1)
+    if config.has_option("BOT", "coinconfig"):
+        print('\'coinconfig\' has been deprecated, please use section coin config instead.\n'
+              'See: http://poloniexlendingbot.readthedocs.io/en/latest/configuration.html#config-per-coin')
+        exit(1)
     return config
 
 
@@ -89,39 +93,27 @@ def get_exchange():
 
 def get_coin_cfg():
     coin_cfg = {}
-    if config.has_option("BOT", "coinconfig"):
-        try:
-            coin_config = (json.loads(config.get("BOT", "coinconfig")))
-            for cur in coin_config:
-                cur = cur.split(':')
-                coin_cfg[cur[0]] = dict(minrate=(Decimal(cur[1])) / 100, maxactive=Decimal(cur[2]),
-                                        maxtolend=Decimal(cur[3]), maxpercenttolend=(Decimal(cur[4])) / 100,
-                                        maxtolendrate=(Decimal(cur[5])) / 100)
-        except Exception as ex:
-            ex.message = ex.message if ex.message else str(ex)
-            print("Coinconfig parsed incorrectly, please refer to the documentation. Error: {0}".format(ex.message))
-    else:
-        for cur in get_all_currencies():
-            if config.has_section(cur):
-                try:
-                    coin_cfg[cur] = {}
-                    coin_cfg[cur]['minrate'] = (Decimal(config.get(cur, 'mindailyrate'))) / 100
-                    coin_cfg[cur]['maxactive'] = Decimal(config.get(cur, 'maxactiveamount'))
-                    coin_cfg[cur]['maxtolend'] = Decimal(config.get(cur, 'maxtolend'))
-                    coin_cfg[cur]['maxpercenttolend'] = (Decimal(config.get(cur, 'maxpercenttolend'))) / 100
-                    coin_cfg[cur]['maxtolendrate'] = (Decimal(config.get(cur, 'maxtolendrate'))) / 100
-                    coin_cfg[cur]['gapmode'] = get_gap_mode(cur, 'gapmode')
-                    coin_cfg[cur]['gapbottom'] = Decimal(get(cur, 'gapbottom', False, 0))
-                    coin_cfg[cur]['gaptop'] = Decimal(get(cur, 'gaptop', False, coin_cfg[cur]['gapbottom']))
-                    coin_cfg[cur]['frrasmin'] = getboolean(cur, 'frrasmin', getboolean('BOT', 'frrasmin'))
-                    coin_cfg[cur]['frrdelta'] = Decimal(get(cur, 'frrdelta', 0.0000))
+    for cur in get_all_currencies():
+        if config.has_section(cur):
+            try:
+                coin_cfg[cur] = {}
+                coin_cfg[cur]['minrate'] = (Decimal(config.get(cur, 'mindailyrate'))) / 100
+                coin_cfg[cur]['maxactive'] = Decimal(config.get(cur, 'maxactiveamount'))
+                coin_cfg[cur]['maxtolend'] = Decimal(config.get(cur, 'maxtolend'))
+                coin_cfg[cur]['maxpercenttolend'] = (Decimal(config.get(cur, 'maxpercenttolend'))) / 100
+                coin_cfg[cur]['maxtolendrate'] = (Decimal(config.get(cur, 'maxtolendrate'))) / 100
+                coin_cfg[cur]['gapmode'] = get_gap_mode(cur, 'gapmode')
+                coin_cfg[cur]['gapbottom'] = Decimal(get(cur, 'gapbottom', False, 0))
+                coin_cfg[cur]['gaptop'] = Decimal(get(cur, 'gaptop', False, coin_cfg[cur]['gapbottom']))
+                coin_cfg[cur]['frrasmin'] = getboolean(cur, 'frrasmin', getboolean('BOT', 'frrasmin'))
+                coin_cfg[cur]['frrdelta'] = Decimal(get(cur, 'frrdelta', 0.0000))
 
-                except Exception as ex:
-                    ex.message = ex.message if ex.message else str(ex)
-                    print("Coinconfig for " + cur + " parsed incorrectly, please refer to the documentation. "
-                          "Error: {0}".format(ex.message))
-                    # Need to raise this exception otherwise the bot will continue if you configured one cur correctly
-                    raise
+            except Exception as ex:
+                ex.message = ex.message if ex.message else str(ex)
+                print("Coin Config for " + cur + " parsed incorrectly, please refer to the documentation. "
+                      "Error: {0}".format(ex.message))
+                # Need to raise this exception otherwise the bot will continue if you configured one cur correctly
+                raise
     return coin_cfg
 
 


### PR DESCRIPTION
To reduce development effort we should maintain only one coin specific configuration as suggested in #364, as it seems that coinconfig is broken in latest version, I suggest removing it finally.

This sort of fixes https://github.com/BitBotFactory/poloniexlendingbot/issues/609 by telling the user to use the section config.


## Types of changes
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [x] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
- [x] **I have read CONTRIBUTING.md**
- [x] **I fully understand [Github Flow.](https://guides.github.com/introduction/flow/)**
- [x] **My code adheres to the [code style of this project.](https://poloniexlendingbot.readthedocs.io/en/latest/contributing.html)**
- [x] **I have updated the documentation in /docs if I have changed the config, arguments, logic in how the bot works, or anything that understandably needs a documentation change.**
- [x] **I have updated the config file accordingly if my change requires a new configuration setting or changes an existing one.**
- [ ] **I have tested the bot with no issues for 24 continuous hours. If issues were experienced, they have been patched and tested again.**
